### PR TITLE
Add mining fee to the mined block

### DIFF
--- a/src/main-v3.js
+++ b/src/main-v3.js
@@ -49,15 +49,16 @@ class Blockchain{
     }
 
     minePendingTransactions(miningRewardAddress){
+        const rewardTx = new Transaction(null, miningRewardAddress, this.miningReward);
+        this.pendingTransactions.push(rewardTx);
+        
         let block = new Block(Date.now(), this.pendingTransactions, this.getLatestBlock().hash);
         block.mineBlock(this.difficulty);
 
         console.log('Block successfully mined!');
         this.chain.push(block);
 
-        this.pendingTransactions = [
-            new Transaction(null, miningRewardAddress, this.miningReward)
-        ];
+        this.pendingTransactions = [];
     }
 
     createTransaction(transaction){


### PR DESCRIPTION
Miner's reward transaction should be part of the mined blocked. It doesn't make any sense for a miner to put his reward into the pending txs. A miner want to ensure he gets payed as soon as he did the job.